### PR TITLE
feat: for npm5, use the prepare script instead of prepublish

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,18 @@ const optionalDependencies = 'optionalDependencies';
 
 const undefsafe = require('undefsafe');
 
-function addProtect(pkg) {
+function getNewScriptContent(scriptContent, cmd) {
+  if (scriptContent) {
+    // only add the command if it's not already in the script
+    if (scriptContent.indexOf(cmd) === -1) {
+      return cmd + '; ' + scriptContent;
+    }
+    return scriptContent;
+  }
+  return cmd;
+}
+
+function addProtect(pkg, npmScript) {
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
@@ -22,15 +33,7 @@ function addProtect(pkg) {
   pkg.scripts['snyk-protect'] = 'snyk protect';
 
   const cmd = 'npm run snyk-protect';
-  const runScript = pkg.scripts.prepublish;
-  if (runScript) {
-    // only add the prepublish if it's not already in the prepublish
-    if (runScript.indexOf(cmd) === -1) {
-      pkg.scripts.prepublish = cmd + ' && ' + runScript;
-    }
-  } else {
-    pkg.scripts.prepublish = cmd;
-  }
+  pkg.scripts[npmScript] = getNewScriptContent(pkg.scripts[npmScript], cmd);
 
   // legacy check for `postinstall`, if `npm run snyk-protect` is in there
   // we'll replace it with `true` so it can be cleanly swapped out
@@ -63,10 +66,10 @@ function addTest(pkg) {
   return true;
 }
 
-function add(pkg, type, version) {
+function add(pkg, type, version, npmScript) {
   let res = null;
   if (type === 'protect') {
-    res = addProtect(pkg);
+    res = addProtect(pkg, npmScript || 'prepublish');
   }
 
   if (type === 'test') {
@@ -101,6 +104,7 @@ function updateSnykVersion(pkg, version) {
   const testing = (scripts.test || '').includes('snyk test');
   const protectCmd = 'npm run snyk-protect';
   const protecting = [
+    'prepare',
     'prepublish',
     'postinstall',
   ].find(key => (scripts[key] || '').includes(protectCmd));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,6 +28,17 @@ test('add(protect)', t => {
   t.end();
 });
 
+test('add(protect) npm 5', t => {
+  const pkg = getPkg();
+
+  lib.add(pkg, 'protect', v, 'prepare');
+  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
 test('add(test && protect) on empty package', t => {
   const pkg = {
     name: 'empty',
@@ -62,8 +73,8 @@ test('already testing moves to prod deps when protect', t => {
   pkg.devDependencies.snyk = oldVersion;
   pkg.scripts.test = ' && snyk test';
 
-  lib.add(pkg, 'protect', v);
-  t.match(pkg.scripts.prepublish, 'npm run snyk-protect', 'contains protect command');
+  lib.add(pkg, 'protect', v, 'prepare');
+  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.isa(pkg.devDependencies.snyk, undefined, 'snyk stripped from devDeps');
   t.equal(pkg.snyk, true, 'flagged as snyk');


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

For npm >= 5, put 'npm run snyk-protect' in the prepare script, otherwise put it in the prepublish script (as before)

#### Any background context you want to provide?
npm5 will deprecate the prepublish script

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/SC-3539
