### PR TITLE
chore: remove babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["es2015", "stage-3"],
-  "plugins": ["transform-runtime"]
-}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,26 @@
 sudo: false
 language: node_js
+node_js:
+  - "12"
+  - "10"
+  - "8"
+  - "6"
 cache:
   directories:
     - node_modules
+install:
+  - npm install
+script:
+  - npm test
+jobs:
+  include:
+    - stage: release
+      if: branch = master AND type != pull_request
+      node_js: "10"
+      script:
+        - npx semantic-release
+branches:
+  only:
+    - master
 notifications:
   email: false
-node_js:
-  - '6'
-  - '5'
-  - '4'
-  - '0.10'
-before_script:
-  - npm prune
-  - npm run es5ify
-after_success:
-  - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
-  - python travis_after_all.py
-  - export $(cat .to_export_back) &> /dev/null
-  - npm run semantic-release
-branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,14 @@
 'use strict';
 
-// polyfilling a couple of ES6 bits (Array.find & String.includes)
-require('core-js/fn/array/find');
-require('core-js/fn/string/includes');
-
-module.exports.add = add;
-module.exports.updateSnykVersion = updateSnykVersion;
-
 const dependencies = 'dependencies';
 const devDependencies = 'devDependencies';
 const peerDependencies = 'peerDependencies';
 const optionalDependencies = 'optionalDependencies';
 
-const undefsafe = require('undefsafe');
+module.exports = {
+  add,
+  updateSnykVersion,
+};
 
 function getNewScriptContent(scriptContent, cmd) {
   if (scriptContent) {
@@ -98,7 +94,7 @@ function updateSnykVersion(pkg, version) {
     devDependencies,
     peerDependencies,
     optionalDependencies,
-  ].find(key => undefsafe(pkg, key + '.snyk'));
+  ].find((key) => pkg[key] && pkg[key]['snyk']);
 
   const scripts = pkg.scripts || {};
   const testing = (scripts.test || '').includes('snyk test');

--- a/package.json
+++ b/package.json
@@ -2,41 +2,34 @@
   "name": "snyk-add-to-package",
   "description": "Adds Snyk to the package dependencies",
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
-    "es5ify": "babel --ignore=node_modules . -d .",
     "cover": "tap -R spec --cov --coverage-report=lcov test/*.test.js",
     "test": "tap -R spec test/*.test.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "keywords": [],
-  "author": "Remy Sharp",
+  "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "babel-cli": "^6.9.0",
-    "babel-plugin-es6-promise": "^1.0.0",
-    "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-3": "^6.5.0",
-    "semantic-release": "^4.3.5",
-    "tap": "^5.7.2",
-    "tap-only": "0.0.5"
+    "tap": "^12.6.1"
   },
-  "dependencies": {
-    "babel-runtime": "^6.9.2",
-    "undefsafe": "^1.1.0"
-  },
-  "peerDependencies": {
-    "core-js": "*"
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Snyk/add-to-package.git"
+    "url": "https://github.com/snyk/add-to-package.git"
   },
   "bugs": {
-    "url": "https://github.com/Snyk/add-to-package/issues"
+    "url": "https://github.com/snyk/add-to-package/issues"
   },
-  "homepage": "https://github.com/Snyk/add-to-package#readme",
-  "version": "1.0.0",
+  "homepage": "https://github.com/snyk/add-to-package#readme",
   "directories": {
     "test": "test"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-const test = require('tap-only');
+const { test } = require('tap');
 const lib = require('../');
 const fs = require('fs');
 const v = '2.0.0';


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node < 6

### Why

`babel` is messing with things when using this module. As we've dropped support for Node < 6 in the Snyk CLI we can drop support here too.