### PR TITLE
feat: move package to @snyk/add-to-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 This adds Snyk to the node `package.json` file, as the correct dependency type (which depends on whether the user is protecting or testing).
 
+### Note
+
+This package was previously published to npm as `snyk-add-to-package` and has
+been moved to `@snyk/add-to-package`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "snyk-add-to-package",
+  "name": "@snyk/add-to-package",
   "description": "Adds Snyk to the package dependencies",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
- `snyk-add-to-package` is not owned by `snyk`, so move it into the `snyk` npm org