### PR TITLE
fix: preserve prepublish if present

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,16 +26,33 @@ function addProtect(pkg, npmScript) {
     pkg.scripts = {};
   }
 
-  pkg.scripts['snyk-protect'] = 'snyk protect';
+  const protectCmd = 'npm run snyk-protect';
 
-  const cmd = 'npm run snyk-protect';
-  pkg.scripts[npmScript] = getNewScriptContent(pkg.scripts[npmScript], cmd);
+  const existingScript = [
+    'prepare',
+    'prepublish',
+  ].find(key => pkg.scripts[key] || '');
 
+  if (existingScript) {
+    // if we have one, keep it
+    npmScript = existingScript;
+  }
+
+  const protecting = [
+    'prepare',
+    'prepublish',
+  ].find(key => (pkg.scripts[key] || '').includes(protectCmd));
+
+  // don't add anything if there is already protect command
+  if (!protecting) {
+    pkg.scripts['snyk-protect'] = 'snyk protect';
+    pkg.scripts[npmScript] = getNewScriptContent(pkg.scripts[npmScript], protectCmd);
+  }
   // legacy check for `postinstall`, if `npm run snyk-protect` is in there
   // we'll replace it with `true` so it can be cleanly swapped out
   const postinstall = pkg.scripts.postinstall;
-  if (postinstall && postinstall.indexOf(cmd) !== -1) {
-    pkg.scripts.postinstall = postinstall.replace(cmd, 'true');
+  if (postinstall && postinstall.indexOf(protectCmd) !== -1) {
+    pkg.scripts.postinstall = postinstall.replace(protectCmd, 'true');
   }
 
   pkg.snyk = true;
@@ -65,7 +82,7 @@ function addTest(pkg) {
 function add(pkg, type, version, npmScript) {
   let res = null;
   if (type === 'protect') {
-    res = addProtect(pkg, npmScript || 'prepublish');
+    res = addProtect(pkg, npmScript || 'prepare');
   }
 
   if (type === 'test') {

--- a/test/fixtures/missing-snyk-protect-package.json
+++ b/test/fixtures/missing-snyk-protect-package.json
@@ -1,0 +1,14 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "prepublish": "npm run snyk-protect"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/prepublish-without-snyk-package.json
+++ b/test/fixtures/prepublish-without-snyk-package.json
@@ -1,0 +1,15 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/with-prepare-and-prepublish-package.json
+++ b/test/fixtures/with-prepare-and-prepublish-package.json
@@ -1,0 +1,16 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepare": "npm run test",
+    "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/with-prepublish-package.json
+++ b/test/fixtures/with-prepublish-package.json
@@ -1,0 +1,15 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}


### PR DESCRIPTION
- If a user already has `prepublish`, don't add prepare on top. keep whatever they already have to avoid creating two scripts
- change default to `prepare` as `prepublish` is deprecated` as of npm5
- added tests

https://github.com/snyk/registry/pull/8747