### PR TITLE
feat: add yarn support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,26 +25,36 @@ function addProtect(pkg, cmdScript, packageManager = 'npm') {
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
-
-  const protectCmd = packageManager + ' run snyk-protect';
+  const protectCmdWithoutPkgManager = ' run snyk-protect';
+  const protectCmd = packageManager + protectCmdWithoutPkgManager;
 
   const existingScript = [
     'prepare',
     'prepublish',
   ].find(key => pkg.scripts[key] || '');
 
+
   if (existingScript) {
     // if we have one, keep it
     cmdScript = existingScript;
-  }
+    const scriptContent = pkg.scripts[existingScript];
 
-  const protecting = existingScript && existingScript.includes(protectCmd);
+    // if it is the wrong package manager then update it
+    if (scriptContent.indexOf(protectCmdWithoutPkgManager) !== -1
+      && packageManager === 'yarn') {
+      const replaceCmd = 'npm' + protectCmdWithoutPkgManager;
+      pkg.scripts[existingScript] = scriptContent
+        .replace(replaceCmd, protectCmd);
+    }
+  }
+  const protecting = existingScript && (pkg.scripts[existingScript].indexOf(protectCmd) !== -1);
 
   // don't add anything if there is already protect command
   if (!protecting) {
     pkg.scripts['snyk-protect'] = 'snyk protect';
     pkg.scripts[cmdScript] = getNewScriptContent(pkg.scripts[cmdScript], protectCmd);
   }
+
   // legacy check for `postinstall`, if `npm run snyk-protect` is in there
   // we'll replace it with `true` so it can be cleanly swapped out
   const postinstall = pkg.scripts.postinstall;

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,12 +21,12 @@ function getNewScriptContent(scriptContent, cmd) {
   return cmd;
 }
 
-function addProtect(pkg, npmScript) {
+function addProtect(pkg, cmdScript, packageManager = 'npm') {
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
 
-  const protectCmd = 'npm run snyk-protect';
+  const protectCmd = packageManager + ' run snyk-protect';
 
   const existingScript = [
     'prepare',
@@ -35,18 +35,15 @@ function addProtect(pkg, npmScript) {
 
   if (existingScript) {
     // if we have one, keep it
-    npmScript = existingScript;
+    cmdScript = existingScript;
   }
 
-  const protecting = [
-    'prepare',
-    'prepublish',
-  ].find(key => (pkg.scripts[key] || '').includes(protectCmd));
+  const protecting = existingScript && existingScript.includes(protectCmd);
 
   // don't add anything if there is already protect command
   if (!protecting) {
     pkg.scripts['snyk-protect'] = 'snyk protect';
-    pkg.scripts[npmScript] = getNewScriptContent(pkg.scripts[npmScript], protectCmd);
+    pkg.scripts[cmdScript] = getNewScriptContent(pkg.scripts[cmdScript], protectCmd);
   }
   // legacy check for `postinstall`, if `npm run snyk-protect` is in there
   // we'll replace it with `true` so it can be cleanly swapped out
@@ -79,10 +76,10 @@ function addTest(pkg) {
   return true;
 }
 
-function add(pkg, type, version, npmScript) {
+function add(pkg, type, version, cmdScript, packageManager) {
   let res = null;
   if (type === 'protect') {
-    res = addProtect(pkg, npmScript || 'prepare');
+    res = addProtect(pkg, cmdScript || 'prepare', packageManager);
   }
 
   if (type === 'test') {
@@ -94,11 +91,11 @@ function add(pkg, type, version, npmScript) {
   }
 
   if (version) {
-    updateSnykVersion(pkg, version);
+    updateSnykVersion(pkg, version, packageManager);
   }
 }
 
-function updateSnykVersion(pkg, version) {
+function updateSnykVersion(pkg, version, packageManager = 'npm') {
   /**
    * 1. find where snyk is sitting
    * 2. check whether protect or test is being used, if
@@ -115,7 +112,7 @@ function updateSnykVersion(pkg, version) {
 
   const scripts = pkg.scripts || {};
   const testing = (scripts.test || '').includes('snyk test');
-  const protectCmd = 'npm run snyk-protect';
+  const protectCmd = packageManager + ' run snyk-protect';
   const protecting = [
     'prepare',
     'prepublish',

--- a/test/fixtures/missing-snyk-protect-package-yarn.json
+++ b/test/fixtures/missing-snyk-protect-package-yarn.json
@@ -1,0 +1,14 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "prepublish": "yarn run snyk-protect"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/npm-with-prepublish-simple-now-yarn.json
+++ b/test/fixtures/npm-with-prepublish-simple-now-yarn.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect && yarn run build"
+    "prepublish": "npm run snyk-protect"
   },
   "dependencies": {
     "@google-cloud/promisify": "^0.3.0",

--- a/test/fixtures/prepublish-without-snyk-package-yarn.json
+++ b/test/fixtures/prepublish-without-snyk-package-yarn.json
@@ -1,0 +1,15 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "yarn run build"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/with-prepare-and-prepublish-package-yarn.json
+++ b/test/fixtures/with-prepare-and-prepublish-package-yarn.json
@@ -1,0 +1,16 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepare": "yarn run test",
+    "prepublish": "yarn run build"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/with-prepublish-npm-but-now-yarn.json
+++ b/test/fixtures/with-prepublish-npm-but-now-yarn.json
@@ -1,0 +1,15 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/fixtures/with-prepublish-package-yarn.json
+++ b/test/fixtures/with-prepublish-package-yarn.json
@@ -1,0 +1,15 @@
+{
+  "name": "package-lock-exact-match",
+  "version": "1.0.0",
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "yarn run snyk-protect"
+  },
+  "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
+    "@snyk/email-templates": "1.14.1",
+    "debug": "2.6.7",
+    "lodash": "^1.3.1",
+    "semver": "3.0.0"
+  }
+}

--- a/test/npm.test.js
+++ b/test/npm.test.js
@@ -1,0 +1,149 @@
+const { test } = require('tap');
+const lib = require('../lib');
+const fs = require('fs');
+const v = '2.0.0';
+
+function getPkg() {
+  return JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8'));
+}
+
+function loadFile(fileName) {
+  return JSON.parse(fs.readFileSync(__dirname + '/fixtures/' + fileName, 'utf8'));
+}
+
+test('add(test)', t => {
+  const pkg = getPkg();
+
+  lib.add(pkg, 'test', v);
+  t.match(pkg.scripts.test, 'snyk test', 'contains test command');
+  t.equal(pkg.devDependencies.snyk, '^' + v, 'includes snyk and latest');
+
+  t.end();
+});
+
+test('add(protect)', t => {
+  const pkg = getPkg();
+
+  lib.add(pkg, 'protect', v);
+  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  t.ok(!pkg.scripts.prepublish, 'does not contain prepublish');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('script exists but not snyk protect (protect)', t => {
+  const pkg = loadFile('missing-snyk-protect-package.json');
+
+  lib.add(pkg, 'protect', v);
+  t.match(pkg.scripts.prepublish, 'npm run snyk-protect', 'prepublish preserved');
+  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('do not add another script if one exists (protect)', t => {
+  const pkg = loadFile('with-prepublish-package.json');
+  lib.add(pkg, 'protect', v);
+  t.equal(pkg.scripts.prepublish, 'npm run snyk-protect', 'contains protect command');
+  t.ok(!pkg.scripts.prepare, 'prepare not added');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('update the same script that exists (protect)', t => {
+  const pkg = loadFile('prepublish-without-snyk-package.json');
+  lib.add(pkg, 'protect', v);
+  t.equal(pkg.scripts.prepublish, 'npm run snyk-protect && npm run build', 'contains protect command');
+  t.ok(!pkg.scripts.prepare, 'prepare not added');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('if both prepare/prepublish exists update first one (protect)', t => {
+  const pkg = loadFile('with-prepare-and-prepublish-package.json');
+  lib.add(pkg, 'protect', v);
+  t.equal(pkg.scripts.prepare, 'npm run snyk-protect && npm run test', 'contains protect command');
+  t.equal(pkg.scripts.prepublish, 'npm run build', 'prepublish not changed');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('default to prepare (protect)', t => {
+  const pkg = getPkg();
+  lib.add(pkg, 'protect', v);
+  t.equal(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  t.ok(!pkg.scripts.prepublish, 'prepublish not added');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('add(protect) npm 5', t => {
+  const pkg = getPkg();
+
+  lib.add(pkg, 'protect', v, 'prepare');
+  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('add(test && protect) on empty package', t => {
+  const pkg = {
+    name: 'empty',
+  };
+
+  lib.add(pkg, 'test', v);
+  lib.add(pkg, 'protect', v);
+  t.match(pkg.scripts.test, 'snyk test', 'contains test command');
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+
+  t.deepEqual(pkg, {
+    name: 'empty',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      prepare: 'npm run snyk-protect',
+      test: 'snyk test',
+    },
+    devDependencies: {},
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    snyk: true,
+  }, 'structured as expected');
+
+  t.end();
+});
+
+
+test('already testing moves to prod deps when protect', t => {
+  const pkg = getPkg();
+  const oldVersion = '1.0.0';
+  pkg.devDependencies.snyk = oldVersion;
+  pkg.scripts.test = ' && snyk test';
+
+  lib.add(pkg, 'protect', v, 'prepare');
+  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.isa(pkg.devDependencies.snyk, undefined, 'snyk stripped from devDeps');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});

--- a/test/yarn.test.js
+++ b/test/yarn.test.js
@@ -136,10 +136,22 @@ test('already testing moves to prod deps when protect', t => {
   t.end();
 });
 
-test('update the same script that exists (protect) from npm to yarn', t => {
+test('update the same script that exists (protect with extra commands) from npm to yarn', t => {
   const pkg = loadFile('with-prepublish-npm-but-now-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
   t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect && yarn run build', 'contains protect command');
+  t.ok(!pkg.scripts.prepare, 'prepare not added');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('update the same script that exists (protect) from npm to yarn', t => {
+  const pkg = loadFile('npm-with-prepublish-simple-now-yarn.json');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect', 'contains protect command');
   t.ok(!pkg.scripts.prepare, 'prepare not added');
 
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');

--- a/test/yarn.test.js
+++ b/test/yarn.test.js
@@ -1,5 +1,5 @@
 const { test } = require('tap');
-const lib = require('../');
+const lib = require('../lib');
 const fs = require('fs');
 const v = '2.0.0';
 
@@ -14,7 +14,7 @@ function loadFile(fileName) {
 test('add(test)', t => {
   const pkg = getPkg();
 
-  lib.add(pkg, 'test', v);
+  lib.add(pkg, 'test', v, undefined, 'yarn');
   t.match(pkg.scripts.test, 'snyk test', 'contains test command');
   t.equal(pkg.devDependencies.snyk, '^' + v, 'includes snyk and latest');
 
@@ -23,10 +23,9 @@ test('add(test)', t => {
 
 test('add(protect)', t => {
   const pkg = getPkg();
-
-  lib.add(pkg, 'protect', v);
-  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepublish, 'doe not contains prepublish');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.match(pkg.scripts.prepare, 'yarn run snyk-protect', 'contains protect command');
+  t.ok(!pkg.scripts.prepublish, 'does not contain prepublish');
 
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.equal(pkg.snyk, true, 'flagged as snyk');
@@ -35,10 +34,10 @@ test('add(protect)', t => {
 });
 
 test('script exists but not snyk protect (protect)', t => {
-  const pkg = loadFile('missing-snyk-protect-package.json');
+  const pkg = loadFile('missing-snyk-protect-package-yarn.json');
 
-  lib.add(pkg, 'protect', v);
-  t.match(pkg.scripts.prepublish, 'npm run snyk-protect', 'prepublish preserved');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.match(pkg.scripts.prepublish, 'yarn run snyk-protect', 'prepublish preserved');
   t.ok(!pkg.scripts.prepare, 'prepare not added');
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.equal(pkg.snyk, true, 'flagged as snyk');
@@ -47,9 +46,9 @@ test('script exists but not snyk protect (protect)', t => {
 });
 
 test('do not add another script if one exists (protect)', t => {
-  const pkg = loadFile('with-prepublish-package.json');
-  lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepublish, 'npm run snyk-protect', 'contains protect command');
+  const pkg = loadFile('with-prepublish-package-yarn.json');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect', 'contains protect command');
   t.ok(!pkg.scripts.prepare, 'prepare not added');
 
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
@@ -59,9 +58,9 @@ test('do not add another script if one exists (protect)', t => {
 });
 
 test('update the same script that exists (protect)', t => {
-  const pkg = loadFile('prepublish-without-snyk-package.json');
-  lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepublish, 'npm run snyk-protect && npm run build', 'contains protect command');
+  const pkg = loadFile('prepublish-without-snyk-package-yarn.json');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect && yarn run build', 'contains protect command');
   t.ok(!pkg.scripts.prepare, 'prepare not added');
 
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
@@ -71,10 +70,10 @@ test('update the same script that exists (protect)', t => {
 });
 
 test('if both prepare/prepublish exists update first one (protect)', t => {
-  const pkg = loadFile('with-prepare-and-prepublish-package.json');
-  lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepare, 'npm run snyk-protect && npm run test', 'contains protect command');
-  t.equal(pkg.scripts.prepublish, 'npm run build', 'prepublish not changed');
+  const pkg = loadFile('with-prepare-and-prepublish-package-yarn.json');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.equal(pkg.scripts.prepare, 'yarn run snyk-protect && yarn run test', 'contains protect command');
+  t.equal(pkg.scripts.prepublish, 'yarn run build', 'prepublish not changed');
 
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.equal(pkg.snyk, true, 'flagged as snyk');
@@ -84,21 +83,10 @@ test('if both prepare/prepublish exists update first one (protect)', t => {
 
 test('default to prepare (protect)', t => {
   const pkg = getPkg();
-  lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.equal(pkg.scripts.prepare, 'yarn run snyk-protect', 'contains protect command');
   t.ok(!pkg.scripts.prepublish, 'prepublish not added');
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
-});
-
-test('add(protect) npm 5', t => {
-  const pkg = getPkg();
-
-  lib.add(pkg, 'protect', v, 'prepare');
-  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.equal(pkg.snyk, true, 'flagged as snyk');
 
@@ -110,8 +98,8 @@ test('add(test && protect) on empty package', t => {
     name: 'empty',
   };
 
-  lib.add(pkg, 'test', v);
-  lib.add(pkg, 'protect', v);
+  lib.add(pkg, 'test', v, undefined, 'yarn');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
   t.match(pkg.scripts.test, 'snyk test', 'contains test command');
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
 
@@ -119,7 +107,7 @@ test('add(test && protect) on empty package', t => {
     name: 'empty',
     scripts: {
       'snyk-protect': 'snyk protect',
-      prepare: 'npm run snyk-protect',
+      prepare: 'yarn run snyk-protect',
       test: 'snyk test',
     },
     devDependencies: {},
@@ -127,7 +115,7 @@ test('add(test && protect) on empty package', t => {
       snyk: `^${v}`,
     },
     snyk: true,
-  }, 'strctured as expected');
+  }, 'structured as expected');
 
   t.end();
 });
@@ -139,10 +127,22 @@ test('already testing moves to prod deps when protect', t => {
   pkg.devDependencies.snyk = oldVersion;
   pkg.scripts.test = ' && snyk test';
 
-  lib.add(pkg, 'protect', v, 'prepare');
-  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
+  lib.add(pkg, 'protect', v, 'prepare', 'yarn');
+  t.match(pkg.scripts.prepare, 'yarn run snyk-protect', 'contains protect command');
   t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.isa(pkg.devDependencies.snyk, undefined, 'snyk stripped from devDeps');
+  t.equal(pkg.snyk, true, 'flagged as snyk');
+
+  t.end();
+});
+
+test('update the same script that exists (protect) from npm to yarn', t => {
+  const pkg = loadFile('with-prepublish-npm-but-now-yarn.json');
+  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect && yarn run build', 'contains protect command');
+  t.ok(!pkg.scripts.prepare, 'prepare not added');
+
+  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
   t.equal(pkg.snyk, true, 'flagged as snyk');
 
   t.end();


### PR DESCRIPTION
# What does this do?
Allow to pass the packageManager to be passed as as a parameter
Replace npm with yarn if found, today we still add `npm` into yarn projects!