### PR TITLE
Use new snyk protect

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testMatch: [
+    '<rootDir>/test/*.test.js'
+  ],
+  modulePathIgnorePatterns: [
+    '<rootDir>/test/.*fixtures/*'
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testMatch: [
-    '<rootDir>/test/*.test.js'
+    '<rootDir>/test/unit/**/*.test.js',
+    '<rootDir>/test/acceptance/**/*.test.js',
   ],
   modulePathIgnorePatterns: [
     '<rootDir>/test/.*fixtures/*'

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,10 @@ const optionalDependencies = 'optionalDependencies';
 
 module.exports = {
   add,
-  updateSnykVersion,
+  updateSnykDependency,
+  updateSnykProtectDependency,
+  isProtecting,
+  isTesting,
 };
 
 function getNewScriptContent(scriptContent, cmd) {
@@ -33,7 +36,6 @@ function addProtect(pkg, cmdScript, packageManager = 'npm') {
     'prepublish',
   ].find(key => pkg.scripts[key] || '');
 
-
   if (existingScript) {
     // if we have one, keep it
     cmdScript = existingScript;
@@ -49,11 +51,11 @@ function addProtect(pkg, cmdScript, packageManager = 'npm') {
   }
   const protecting = existingScript && (pkg.scripts[existingScript].indexOf(protectCmd) !== -1);
 
-  // don't add anything if there is already protect command
   if (!protecting) {
-    pkg.scripts['snyk-protect'] = 'snyk protect';
     pkg.scripts[cmdScript] = getNewScriptContent(pkg.scripts[cmdScript], protectCmd);
   }
+
+  pkg.scripts['snyk-protect'] = 'snyk-protect';
 
   // legacy check for `postinstall`, if `npm run snyk-protect` is in there
   // we'll replace it with `true` so it can be cleanly swapped out
@@ -86,7 +88,8 @@ function addTest(pkg) {
   return true;
 }
 
-function add(pkg, type, version, cmdScript, packageManager) {
+// cmdScript is the lifecycle script - either `prepare` or `prepublish`
+function add(pkg, type, version, cmdScript, packageManager = 'npm') {
   let res = null;
   if (type === 'protect') {
     res = addProtect(pkg, cmdScript || 'prepare', packageManager);
@@ -101,58 +104,69 @@ function add(pkg, type, version, cmdScript, packageManager) {
   }
 
   if (version) {
-    updateSnykVersion(pkg, version, packageManager);
+    const protecting = isProtecting(pkg, packageManager);
+    updateSnykProtectDependency(pkg, protecting, version);
+    
+    const testing = isTesting(pkg);
+    updateSnykDependency(pkg, testing, version);
   }
 }
 
-function updateSnykVersion(pkg, version, packageManager = 'npm') {
-  /**
-   * 1. find where snyk is sitting
-   * 2. check whether protect or test is being used, if
-   *    protect is being used, move dep from devDeps to prod deps
-   * 3. then upgrade the version
-   */
-
-  let key = [
-    dependencies,
-    devDependencies,
-    peerDependencies,
-    optionalDependencies,
-  ].find((key) => pkg[key] && pkg[key]['snyk']);
-
+function isTesting(pkg) {
   const scripts = pkg.scripts || {};
-  const testing = (scripts.test || '').includes('snyk test');
+  return (scripts.test || '').includes('snyk test');
+}
+
+function updateSnykDependency(pkg, testing, version) {
+  if (testing) {
+    const dependencyLocation = [
+      dependencies,
+      devDependencies,
+      peerDependencies,
+      optionalDependencies,
+    ].find((location) => pkg[location] && pkg[location]['snyk']) || devDependencies;
+    if (!pkg[dependencyLocation]) {
+      pkg[dependencyLocation] = {};
+    }
+    pkg[dependencyLocation].snyk = '^' + version;
+  } else {
+    // don't need the `snyk` dep anymore - remove it
+    removeDependency(pkg, dependencies, 'snyk');
+    removeDependency(pkg, devDependencies, 'snyk');
+    removeDependency(pkg, peerDependencies, 'snyk');
+    removeDependency(pkg, optionalDependencies, 'snyk');
+  }
+}
+
+function removeDependency(pkg, dependenciesListName, packageName) {
+  // this would be simpler if we could just do, for example, `delete pkg.dependencies?.snyk`, but that syntax is not available on Node 10 / 12
+  if (pkg[dependenciesListName]) {
+    if (pkg[dependenciesListName][packageName]) {
+      delete pkg[dependenciesListName][packageName];
+    }
+  }
+}
+
+function isProtecting(pkg, packageManager) {
+  const scripts = pkg.scripts || {};
   const protectCmd = packageManager + ' run snyk-protect';
-  const protecting = [
+  return [
     'prepare',
     'prepublish',
     'postinstall',
-  ].find(key => (scripts[key] || '').includes(protectCmd));
+  ].some(key => (scripts[key] || '').includes(protectCmd));
+}
 
-  if (testing && !key) {
-    if (!pkg[devDependencies]) {
-      pkg[devDependencies] = {};
-    }
-
-    key = devDependencies;
-  }
-
-  // if protecting, then always move snyk out of devdeps and optional
+function updateSnykProtectDependency(pkg, protecting, version) {
   if (protecting) {
-    pkg.snyk = true;
-    if (key === devDependencies || key === optionalDependencies) {
-      delete pkg[key].snyk;
-      key = null;
+    if (!pkg.dependencies) {
+      pkg.dependencies = {};
     }
-
-    if (!key) {
-      key = dependencies;
-    }
+    pkg.dependencies['@snyk/protect'] = `^${version}`;
+  } else {
+    removeDependency(pkg, dependencies, '@snyk/protect');
+    removeDependency(pkg, devDependencies, '@snyk/protect');
+    removeDependency(pkg, peerDependencies, '@snyk/protect');
+    removeDependency(pkg, optionalDependencies, '@snyk/protect');
   }
-
-  if (!pkg[key]) {
-    pkg[key] = {};
-  }
-
-  pkg[key].snyk = '^' + version;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ function updateSnykProtectDependency(pkg, protecting, version) {
     if (!pkg.dependencies) {
       pkg.dependencies = {};
     }
-    pkg.dependencies['@snyk/protect'] = `^${version}`;
+    pkg.dependencies['@snyk/protect'] = `latest`;
   } else {
     removeDependency(pkg, dependencies, '@snyk/protect');
     removeDependency(pkg, devDependencies, '@snyk/protect');

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   },
   "scripts": {
     "cover": "tap -R spec --cov --coverage-report=lcov test/*.test.js",
-    "test": "tap -R spec test/*.test.js",
+    "test": "jest",
     "release": "semantic-release"
   },
   "keywords": [],
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
+    "jest": "^27.0.4",
     "semantic-release": "^17.4.4",
     "tap": "^12.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   },
   "scripts": {
     "cover": "tap -R spec --cov --coverage-report=lcov test/*.test.js",
-    "test": "npm run test:acceptance",
+    "test": "npm run test:unit && npm run test:acceptance",
     "test:acceptance": "jest --runInBand \"/test/acceptance/((.+)/)*[^/]+\\.test\\.js\"",
+    "test:unit": "jest --runInBand \"/test/unit/((.+)/)*[^/]+\\.test\\.js\"",
     "release": "semantic-release"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "cover": "tap -R spec --cov --coverage-report=lcov test/*.test.js",
-    "test": "jest",
+    "test": "npm run test:acceptance",
+    "test:acceptance": "jest --runInBand \"/test/acceptance/((.+)/)*[^/]+\\.test\\.js\"",
     "release": "semantic-release"
   },
   "keywords": [],

--- a/test/acceptance/npm.test.js
+++ b/test/acceptance/npm.test.js
@@ -37,10 +37,10 @@ it('add(protect)', () => {
   expect(pkg).toEqual({
     scripts: {
       prepare: 'npm run snyk-protect',
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
@@ -55,10 +55,10 @@ it('script exists but not snyk protect (protect)', () => {
     version: '1.0.0',
     scripts: {
       prepublish: 'npm run snyk-protect',
-      // 'snyk-protect': 'snyk protect',  // this is not in the results - is this a bug?
+      'snyk-protect': 'snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies
     },
     snyk: true,
@@ -73,11 +73,11 @@ it('do not add another script if one exists (protect)', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepublish': 'npm run snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies,
     },
     snyk: true,
@@ -92,11 +92,11 @@ it('update the same script that exists (protect)', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepublish': 'npm run snyk-protect && npm run build',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies,
     },
     snyk: true,
@@ -111,12 +111,12 @@ it('if both prepare/prepublish exists update first one (protect)', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepublish': 'npm run build',
       'prepare': 'npm run snyk-protect && npm run test',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies,
     },
     snyk: true,
@@ -126,14 +126,14 @@ it('if both prepare/prepublish exists update first one (protect)', () => {
 it('default to prepare (protect)', () => {
   const pkg = {};
   lib.add(pkg, 'protect', v);
-  
+
   expect(pkg).toEqual({
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepare': 'npm run snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
@@ -145,11 +145,11 @@ it('add(protect) npm 5', () => {
 
   expect(pkg).toEqual({
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepare': 'npm run snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
@@ -165,19 +165,21 @@ it('add(test && protect) on empty package', () => {
   expect(pkg).toEqual({
     name: 'empty',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       prepare: 'npm run snyk-protect',
       test: 'snyk test',
     },
-    devDependencies: {},
-    dependencies: {
+    devDependencies: {
       snyk: `^${v}`,
+    },
+    dependencies: {
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
 });
 
-it('already testing moves to prod deps when protect', () => {
+it('keeps `snyk` in devDependencies and adds `@snyk/protect` to dependencies if already testing and you add protect', () => {
   const pkg = {
     scripts: {
       test: ' && snyk test',
@@ -191,14 +193,16 @@ it('already testing moves to prod deps when protect', () => {
   
   expect(pkg).toEqual({
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       prepare: 'npm run snyk-protect',
       test: ' && snyk test',
     },
     dependencies: {
+      '@snyk/protect': `^${v}`,
+    },
+    devDependencies: {
       snyk: `^${v}`,
     },
-    devDependencies: {},
     snyk: true,
   });
 });

--- a/test/acceptance/npm.test.js
+++ b/test/acceptance/npm.test.js
@@ -43,7 +43,7 @@ describe('add(protect)', () => {
         'snyk-protect': 'snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
       },
       snyk: true,
     });
@@ -61,7 +61,7 @@ describe('add(protect)', () => {
         'snyk-protect': 'snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies
       },
       snyk: true,
@@ -80,7 +80,7 @@ describe('add(protect)', () => {
         'prepublish': 'npm run snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies,
       },
       snyk: true,
@@ -99,7 +99,7 @@ describe('add(protect)', () => {
         'prepublish': 'npm run snyk-protect && npm run build',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies,
       },
       snyk: true,
@@ -119,7 +119,7 @@ describe('add(protect)', () => {
         'prepare': 'npm run snyk-protect && npm run test',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies,
       },
       snyk: true,
@@ -136,7 +136,7 @@ describe('add(protect)', () => {
         'prepare': 'npm run snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
       },
       snyk: true,
     });
@@ -162,7 +162,7 @@ describe('add(protect)', () => {
           test: ' && snyk test',
         },
         dependencies: {
-          '@snyk/protect': `^${v}`,
+          '@snyk/protect': `latest`,
         },
         devDependencies: {
           snyk: `^${v}`,
@@ -192,7 +192,7 @@ describe('add(test) and add(protect)', () => {
         snyk: `^${v}`,
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
       },
       snyk: true,
     });

--- a/test/acceptance/npm.test.js
+++ b/test/acceptance/npm.test.js
@@ -3,102 +3,165 @@ const fs = require('fs');
 const path = require('path');
 const v = '2.0.0';
 
-function getPkg() {
-  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'));
-}
-
 function loadFile(fileName) {
   return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/' + fileName), 'utf8'));
 }
 
-it('add(test)', () => {
-  const pkg = getPkg();
+// these are in each fixture package.json
+const fixtureDependencies = {
+  '@google-cloud/promisify': '^0.3.0',
+  '@snyk/email-templates': '1.14.1',
+  debug: '2.6.7',
+  lodash: '^1.3.1',
+  semver: '3.0.0'
+}
 
+it('add(test)', () => {
+  const pkg = {};
   lib.add(pkg, 'test', v);
-  expect(pkg.scripts.test).toContain('snyk test');
-  expect(pkg.devDependencies.snyk).toBe('^' + v);
+
+  expect(pkg).toEqual({
+    scripts: {
+      test: 'snyk test'
+    },
+    devDependencies: {
+      snyk: `^${v}`,
+    }
+  });
 });
 
 it('add(protect)', () => {
-  const pkg = getPkg();
-
+  const pkg = {};
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.prepare).toContain('npm run snyk-protect');
-  expect(pkg.scripts.prepublish).toBeUndefined();
-
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  
+  expect(pkg).toEqual({
+    scripts: {
+      prepare: 'npm run snyk-protect',
+      'snyk-protect': 'snyk protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    snyk: true,
+  });
 });
 
 it('script exists but not snyk protect (protect)', () => {
   const pkg = loadFile('missing-snyk-protect-package.json');
-
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.prepublish).toContain('npm run snyk-protect');
-  expect(pkg.scripts.prepare).toBeUndefined();
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      prepublish: 'npm run snyk-protect',
+      // 'snyk-protect': 'snyk protect',  // this is not in the results - is this a bug?
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies
+    },
+    snyk: true,
+  });
 });
 
 it('do not add another script if one exists (protect)', () => {
   const pkg = loadFile('with-prepublish-package.json');
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.prepublish).toContain('npm run snyk-protect');
-  expect(pkg.scripts.prepare).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepublish': 'npm run snyk-protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies,
+    },
+    snyk: true,
+  });
 });
 
 it('update the same script that exists (protect)', () => {
   const pkg = loadFile('prepublish-without-snyk-package.json');
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.prepublish).toBe('npm run snyk-protect && npm run build');
-  expect(pkg.scripts.prepare).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepublish': 'npm run snyk-protect && npm run build',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies,
+    },
+    snyk: true,
+  });
 });
 
 it('if both prepare/prepublish exists update first one (protect)', () => {
   const pkg = loadFile('with-prepare-and-prepublish-package.json');
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.prepare).toBe('npm run snyk-protect && npm run test');
-  expect(pkg.scripts.prepublish).toBe('npm run build');
-
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepublish': 'npm run build',
+      'prepare': 'npm run snyk-protect && npm run test',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies,
+    },
+    snyk: true,
+  });
 });
 
 it('default to prepare (protect)', () => {
-  const pkg = getPkg();
+  const pkg = {};
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.prepare).toBe('npm run snyk-protect');
-  expect(pkg.scripts.prepublish).toBeUndefined();
-
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  
+  expect(pkg).toEqual({
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepare': 'npm run snyk-protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    snyk: true,
+  });
 });
 
 it('add(protect) npm 5', () => {
-  const pkg = getPkg();
-
+  const pkg = {};
   lib.add(pkg, 'protect', v, 'prepare');
-  expect(pkg.scripts.prepare).toContain('npm run snyk-protect');
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+
+  expect(pkg).toEqual({
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepare': 'npm run snyk-protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    snyk: true,
+  });
 });
 
 it('add(test && protect) on empty package', () => {
   const pkg = {
     name: 'empty',
   };
-
   lib.add(pkg, 'test', v);
   lib.add(pkg, 'protect', v);
-  expect(pkg.scripts.test).toContain('snyk test');
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-
+  
   expect(pkg).toEqual({
     name: 'empty',
     scripts: {
@@ -115,14 +178,27 @@ it('add(test && protect) on empty package', () => {
 });
 
 it('already testing moves to prod deps when protect', () => {
-  const pkg = getPkg();
-  const oldVersion = '1.0.0';
-  pkg.devDependencies.snyk = oldVersion;
-  pkg.scripts.test = ' && snyk test';
+  const pkg = {
+    scripts: {
+      test: ' && snyk test',
+    },
+    devDependencies: {
+      snyk: '1.0.0',
+    },
+  };
 
   lib.add(pkg, 'protect', v, 'prepare');
-  expect(pkg.scripts.prepare).toContain('npm run snyk-protect');
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.devDependencies.snyk).toBeUndefined();
-  expect(pkg.snyk).toBe(true);
+  
+  expect(pkg).toEqual({
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      prepare: 'npm run snyk-protect',
+      test: ' && snyk test',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    devDependencies: {},
+    snyk: true,
+  });
 });

--- a/test/acceptance/npm.test.js
+++ b/test/acceptance/npm.test.js
@@ -1,13 +1,14 @@
-const lib = require('../lib');
+const lib = require('../../lib');
 const fs = require('fs');
+const path = require('path');
 const v = '2.0.0';
 
 function getPkg() {
-  return JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8'));
+  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'));
 }
 
 function loadFile(fileName) {
-  return JSON.parse(fs.readFileSync(__dirname + '/fixtures/' + fileName, 'utf8'));
+  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/' + fileName), 'utf8'));
 }
 
 it('add(test)', () => {

--- a/test/acceptance/yarn.test.js
+++ b/test/acceptance/yarn.test.js
@@ -16,215 +16,207 @@ const fixtureDependencies = {
   semver: '3.0.0'
 }
 
-it('add(test)', () => {
-  const pkg = {};
-  lib.add(pkg, 'test', v, undefined, 'yarn');
+describe('add(test)', () => {
+  it('adds `snyk` dependency and `test` script', () => {
+    const pkg = {};
+    lib.add(pkg, 'test', v, undefined, 'yarn');
 
-  expect(pkg).toEqual({
-    scripts: {
-      test: 'snyk test'
-    },
-    devDependencies: {
-      snyk: `^${v}`,
-    }
+    expect(pkg).toEqual({
+      scripts: {
+        test: 'snyk test'
+      },
+      devDependencies: {
+        snyk: `^${v}`,
+      }
+    });
   });
 });
 
-it('add(protect)', () => {
-  const pkg = {};
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
+describe('add(protect)', () => {
+  it('adds `@snyk/protect` dependency and `prepare` / `snyk-protect` scripts', () => {
+    const pkg = {};
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
 
-  expect(pkg).toEqual({
-    scripts: {
-      prepare: 'yarn run snyk-protect',
-      'snyk-protect': 'snyk-protect',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-    },
-    snyk: true,
+    expect(pkg).toEqual({
+      scripts: {
+        prepare: 'yarn run snyk-protect',
+        'snyk-protect': 'snyk-protect',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+      },
+      snyk: true,
+    });
   });
-});
 
-it('script exists but not snyk protect (protect)', () => {
-  const pkg = loadFile('missing-snyk-protect-package-yarn.json');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  it('adds `@snyk/protect` dependency when a protect script exists but the dependency is missing', () => {
+    const pkg = loadFile('missing-snyk-protect-package-yarn.json');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
 
-  expect(pkg).toEqual({
-    name: 'package-lock-exact-match',
-    version: '1.0.0',
-    scripts: {
-      prepublish: 'yarn run snyk-protect',
-      'snyk-protect': 'snyk-protect',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-      ...fixtureDependencies
-    },
-    snyk: true,
+    expect(pkg).toEqual({
+      name: 'package-lock-exact-match',
+      version: '1.0.0',
+      scripts: {
+        prepublish: 'yarn run snyk-protect',
+        'snyk-protect': 'snyk-protect',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+        ...fixtureDependencies
+      },
+      snyk: true,
+    });
   });
-});
 
-it('do not add another script if one exists (protect)', () => {
-  const pkg = loadFile('with-prepublish-package-yarn.json');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  it('does not add another script if one exists already', () => {
+    const pkg = loadFile('with-prepublish-package-yarn.json');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
 
-  expect(pkg).toEqual({
-    name: 'package-lock-exact-match',
-    version: '1.0.0',
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      'prepublish': 'yarn run snyk-protect',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-      ...fixtureDependencies,
-    },
-    snyk: true,
+    expect(pkg).toEqual({
+      name: 'package-lock-exact-match',
+      version: '1.0.0',
+      scripts: {
+        'snyk-protect': 'snyk-protect',
+        'prepublish': 'yarn run snyk-protect',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+        ...fixtureDependencies,
+      },
+      snyk: true,
+    });
   });
-});
 
-it('update the same script that exists (protect)', () => {
-  const pkg = loadFile('prepublish-without-snyk-package-yarn.json');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  it('updates the same script (`prepublish`) if it exists already and adds missing `@snyk/protect` dependency', () => {
+    const pkg = loadFile('prepublish-without-snyk-package-yarn.json');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
 
-  expect(pkg).toEqual({
-    name: 'package-lock-exact-match',
-    version: '1.0.0',
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      'prepublish': 'yarn run snyk-protect && yarn run build',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-      ...fixtureDependencies,
-    },
-    snyk: true,
+    expect(pkg).toEqual({
+      name: 'package-lock-exact-match',
+      version: '1.0.0',
+      scripts: {
+        'snyk-protect': 'snyk-protect',
+        'prepublish': 'yarn run snyk-protect && yarn run build',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+        ...fixtureDependencies,
+      },
+      snyk: true,
+    });
   });
-});
 
-it('if both prepare/prepublish exists update first one (protect)', () => {
-  const pkg = loadFile('with-prepare-and-prepublish-package-yarn.json');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
+  it('updates `prepare` if both `prepare` and `prepublish` already exist and adds missing `@snyk/protect` dependency', () => {
+    const pkg = loadFile('with-prepare-and-prepublish-package-yarn.json');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
+    
+    expect(pkg).toEqual({
+      name: 'package-lock-exact-match',
+      version: '1.0.0',
+      scripts: {
+        'snyk-protect': 'snyk-protect',
+        'prepublish': 'yarn run build',
+        'prepare': 'yarn run snyk-protect && yarn run test',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+        ...fixtureDependencies,
+      },
+      snyk: true,
+    });
+  });
+
+  describe('if you are already testing', () => {
+    it('keeps `snyk` in devDependencies and adds `@snyk/protect` to dependencies and adds `prepare` and `test` scripts', () => {
+      const pkg = {
+        scripts: {
+          test: ' && snyk test',
+        },
+        devDependencies: {
+          snyk: '1.0.0',
+        },
+      };
+      
+      lib.add(pkg, 'protect', v, 'prepare', 'yarn');
+    
+      expect(pkg).toEqual({
+        scripts: {
+          'snyk-protect': 'snyk-protect',
+          prepare: 'yarn run snyk-protect',
+          test: ' && snyk test',
+        },
+        dependencies: {
+          '@snyk/protect': `^${v}`,
+        },
+        devDependencies: {
+          snyk: `^${v}`,
+        },
+        snyk: true,
+      });
+    });
+  });
+
+  it('updates an existing protect script from npm to yarn', () => {
+    const pkg = loadFile('npm-with-prepublish-simple-now-yarn.json');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
   
-  expect(pkg).toEqual({
-    name: 'package-lock-exact-match',
-    version: '1.0.0',
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      'prepublish': 'yarn run build',
-      'prepare': 'yarn run snyk-protect && yarn run test',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-      ...fixtureDependencies,
-    },
-    snyk: true,
+    expect(pkg).toEqual({
+      name: 'package-lock-exact-match',
+      version: '1.0.0',
+      scripts: {
+        'snyk-protect': 'snyk-protect',
+        prepublish: 'yarn run snyk-protect',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+        ...fixtureDependencies
+      },
+      snyk: true,
+    });
   });
-});
 
-it('default to prepare (protect)', () => {
-  const pkg = {};
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
-
-  expect(pkg).toEqual({
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      'prepare': 'yarn run snyk-protect',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-    },
-    snyk: true,
-  });
-});
-
-it('add(test && protect) on empty package', () => {
-  const pkg = {
-    name: 'empty',
-  };
-  lib.add(pkg, 'test', v, undefined, 'yarn');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
-
-  expect(pkg).toEqual({
-    name: 'empty',
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      prepare: 'yarn run snyk-protect',
-      test: 'snyk test',
-    },
-    devDependencies: {
-      snyk: `^${v}`,
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-    },
-    snyk: true,
-  });
-});
-
-it('keeps `snyk` in devDependencies and adds `@snyk/protect` to dependencies if already testing and you add protect', () => {
-  const pkg = {
-    scripts: {
-      test: ' && snyk test',
-    },
-    devDependencies: {
-      snyk: '1.0.0',
-    },
-  };
+  it('updates an existing protect script (with extra commands) from npm to yarn', () => {
+    const pkg = loadFile('with-prepublish-npm-but-now-yarn.json');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
   
-  lib.add(pkg, 'protect', v, 'prepare', 'yarn');
-
-  expect(pkg).toEqual({
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      prepare: 'yarn run snyk-protect',
-      test: ' && snyk test',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-    },
-    devDependencies: {
-      snyk: `^${v}`,
-    },
-    snyk: true,
+    expect(pkg).toEqual({
+      name: 'package-lock-exact-match',
+      version: '1.0.0',
+      scripts: {
+        'snyk-protect': 'snyk-protect',
+        prepublish: 'yarn run snyk-protect && yarn run build',
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+        ...fixtureDependencies
+      },
+      snyk: true,
+    });
   });
 });
 
-it('update the same script that exists (protect with extra commands) from npm to yarn', () => {
-  const pkg = loadFile('with-prepublish-npm-but-now-yarn.json');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
-
-  expect(pkg).toEqual({
-    name: 'package-lock-exact-match',
-    version: '1.0.0',
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      prepublish: 'yarn run snyk-protect && yarn run build',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-      ...fixtureDependencies
-    },
-    snyk: true,
-  });
-});
-
-it('update the same script that exists (protect) from npm to yarn', () => {
-  const pkg = loadFile('npm-with-prepublish-simple-now-yarn.json');
-  lib.add(pkg, 'protect', v, undefined, 'yarn');
-
-  expect(pkg).toEqual({
-    name: 'package-lock-exact-match',
-    version: '1.0.0',
-    scripts: {
-      'snyk-protect': 'snyk-protect',
-      prepublish: 'yarn run snyk-protect',
-    },
-    dependencies: {
-      '@snyk/protect': `^${v}`,
-      ...fixtureDependencies
-    },
-    snyk: true,
+describe('add(test) and add(protect)', () => {
+  it('add `snyk` and `@snyk/protect` to devDependencies and dependencies (respectively) and add required scripts', () => {
+    const pkg = {
+      name: 'empty',
+    };
+    lib.add(pkg, 'test', v, undefined, 'yarn');
+    lib.add(pkg, 'protect', v, undefined, 'yarn');
+  
+    expect(pkg).toEqual({
+      name: 'empty',
+      scripts: {
+        'snyk-protect': 'snyk-protect',
+        prepare: 'yarn run snyk-protect',
+        test: 'snyk test',
+      },
+      devDependencies: {
+        snyk: `^${v}`,
+      },
+      dependencies: {
+        '@snyk/protect': `^${v}`,
+      },
+      snyk: true,
+    });
   });
 });

--- a/test/acceptance/yarn.test.js
+++ b/test/acceptance/yarn.test.js
@@ -37,10 +37,10 @@ it('add(protect)', () => {
   expect(pkg).toEqual({
     scripts: {
       prepare: 'yarn run snyk-protect',
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
@@ -55,10 +55,10 @@ it('script exists but not snyk protect (protect)', () => {
     version: '1.0.0',
     scripts: {
       prepublish: 'yarn run snyk-protect',
-      // 'snyk-protect': 'snyk protect',  // this is not in the results - is this a bug?
+      'snyk-protect': 'snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies
     },
     snyk: true,
@@ -73,11 +73,11 @@ it('do not add another script if one exists (protect)', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepublish': 'yarn run snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies,
     },
     snyk: true,
@@ -92,11 +92,11 @@ it('update the same script that exists (protect)', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepublish': 'yarn run snyk-protect && yarn run build',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies,
     },
     snyk: true,
@@ -111,12 +111,12 @@ it('if both prepare/prepublish exists update first one (protect)', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepublish': 'yarn run build',
       'prepare': 'yarn run snyk-protect && yarn run test',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies,
     },
     snyk: true,
@@ -129,11 +129,11 @@ it('default to prepare (protect)', () => {
 
   expect(pkg).toEqual({
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       'prepare': 'yarn run snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
@@ -149,19 +149,21 @@ it('add(test && protect) on empty package', () => {
   expect(pkg).toEqual({
     name: 'empty',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       prepare: 'yarn run snyk-protect',
       test: 'snyk test',
     },
-    devDependencies: {},
-    dependencies: {
+    devDependencies: {
       snyk: `^${v}`,
+    },
+    dependencies: {
+      '@snyk/protect': `^${v}`,
     },
     snyk: true,
   });
 });
 
-it('already testing moves to prod deps when protect', () => {
+it('keeps `snyk` in devDependencies and adds `@snyk/protect` to dependencies if already testing and you add protect', () => {
   const pkg = {
     scripts: {
       test: ' && snyk test',
@@ -175,14 +177,16 @@ it('already testing moves to prod deps when protect', () => {
 
   expect(pkg).toEqual({
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       prepare: 'yarn run snyk-protect',
       test: ' && snyk test',
     },
     dependencies: {
+      '@snyk/protect': `^${v}`,
+    },
+    devDependencies: {
       snyk: `^${v}`,
     },
-    devDependencies: {},
     snyk: true,
   });
 });
@@ -195,11 +199,11 @@ it('update the same script that exists (protect with extra commands) from npm to
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       prepublish: 'yarn run snyk-protect && yarn run build',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies
     },
     snyk: true,
@@ -214,11 +218,11 @@ it('update the same script that exists (protect) from npm to yarn', () => {
     name: 'package-lock-exact-match',
     version: '1.0.0',
     scripts: {
-      'snyk-protect': 'snyk protect',
+      'snyk-protect': 'snyk-protect',
       prepublish: 'yarn run snyk-protect',
     },
     dependencies: {
-      snyk: `^${v}`,
+      '@snyk/protect': `^${v}`,
       ...fixtureDependencies
     },
     snyk: true,

--- a/test/acceptance/yarn.test.js
+++ b/test/acceptance/yarn.test.js
@@ -43,7 +43,7 @@ describe('add(protect)', () => {
         'snyk-protect': 'snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
       },
       snyk: true,
     });
@@ -61,7 +61,7 @@ describe('add(protect)', () => {
         'snyk-protect': 'snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies
       },
       snyk: true,
@@ -80,7 +80,7 @@ describe('add(protect)', () => {
         'prepublish': 'yarn run snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies,
       },
       snyk: true,
@@ -99,7 +99,7 @@ describe('add(protect)', () => {
         'prepublish': 'yarn run snyk-protect && yarn run build',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies,
       },
       snyk: true,
@@ -119,7 +119,7 @@ describe('add(protect)', () => {
         'prepare': 'yarn run snyk-protect && yarn run test',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies,
       },
       snyk: true,
@@ -146,7 +146,7 @@ describe('add(protect)', () => {
           test: ' && snyk test',
         },
         dependencies: {
-          '@snyk/protect': `^${v}`,
+          '@snyk/protect': `latest`,
         },
         devDependencies: {
           snyk: `^${v}`,
@@ -168,7 +168,7 @@ describe('add(protect)', () => {
         prepublish: 'yarn run snyk-protect',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies
       },
       snyk: true,
@@ -187,7 +187,7 @@ describe('add(protect)', () => {
         prepublish: 'yarn run snyk-protect && yarn run build',
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
         ...fixtureDependencies
       },
       snyk: true,
@@ -214,7 +214,7 @@ describe('add(test) and add(protect)', () => {
         snyk: `^${v}`,
       },
       dependencies: {
-        '@snyk/protect': `^${v}`,
+        '@snyk/protect': `latest`,
       },
       snyk: true,
     });

--- a/test/acceptance/yarn.test.js
+++ b/test/acceptance/yarn.test.js
@@ -1,13 +1,14 @@
-const lib = require('../lib');
+const lib = require('../../lib');
 const fs = require('fs');
+const path = require('path');
 const v = '2.0.0';
 
 function getPkg() {
-  return JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8'));
+  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'));
 }
 
 function loadFile(fileName) {
-  return JSON.parse(fs.readFileSync(__dirname + '/fixtures/' + fileName, 'utf8'));
+  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/' + fileName), 'utf8'));
 }
 
 it('add(test)', () => {

--- a/test/acceptance/yarn.test.js
+++ b/test/acceptance/yarn.test.js
@@ -3,91 +3,148 @@ const fs = require('fs');
 const path = require('path');
 const v = '2.0.0';
 
-function getPkg() {
-  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8'));
-}
-
 function loadFile(fileName) {
   return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/' + fileName), 'utf8'));
 }
 
-it('add(test)', () => {
-  const pkg = getPkg();
+// these are in each fixture package.json
+const fixtureDependencies = {
+  '@google-cloud/promisify': '^0.3.0',
+  '@snyk/email-templates': '1.14.1',
+  debug: '2.6.7',
+  lodash: '^1.3.1',
+  semver: '3.0.0'
+}
 
+it('add(test)', () => {
+  const pkg = {};
   lib.add(pkg, 'test', v, undefined, 'yarn');
-  expect(pkg.scripts.test).toContain('snyk test');
-  expect(pkg.devDependencies.snyk).toBe('^' + v);
+
+  expect(pkg).toEqual({
+    scripts: {
+      test: 'snyk test'
+    },
+    devDependencies: {
+      snyk: `^${v}`,
+    }
+  });
 });
 
 it('add(protect)', () => {
-  const pkg = getPkg();
+  const pkg = {};
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepare).toContain('yarn run snyk-protect');
-  expect(pkg.scripts.prepublish).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    scripts: {
+      prepare: 'yarn run snyk-protect',
+      'snyk-protect': 'snyk protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    snyk: true,
+  });
 });
 
 it('script exists but not snyk protect (protect)', () => {
   const pkg = loadFile('missing-snyk-protect-package-yarn.json');
-
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepublish).toContain('yarn run snyk-protect');
-  expect(pkg.scripts.prepare).toBeUndefined();
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      prepublish: 'yarn run snyk-protect',
+      // 'snyk-protect': 'snyk protect',  // this is not in the results - is this a bug?
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies
+    },
+    snyk: true,
+  });
 });
 
 it('do not add another script if one exists (protect)', () => {
   const pkg = loadFile('with-prepublish-package-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect');
-  expect(pkg.scripts.prepare).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepublish': 'yarn run snyk-protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies,
+    },
+    snyk: true,
+  });
 });
 
 it('update the same script that exists (protect)', () => {
   const pkg = loadFile('prepublish-without-snyk-package-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect && yarn run build');
-  expect(pkg.scripts.prepare).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepublish': 'yarn run snyk-protect && yarn run build',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies,
+    },
+    snyk: true,
+  });
 });
 
 it('if both prepare/prepublish exists update first one (protect)', () => {
   const pkg = loadFile('with-prepare-and-prepublish-package-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepare).toBe('yarn run snyk-protect && yarn run test');
-  expect(pkg.scripts.prepublish).toBe('yarn run build');
-
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepublish': 'yarn run build',
+      'prepare': 'yarn run snyk-protect && yarn run test',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies,
+    },
+    snyk: true,
+  });
 });
 
 it('default to prepare (protect)', () => {
-  const pkg = getPkg();
+  const pkg = {};
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepare).toBe('yarn run snyk-protect');
-  expect(pkg.scripts.prepublish).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      'prepare': 'yarn run snyk-protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    snyk: true,
+  });
 });
 
 it('add(test && protect) on empty package', () => {
   const pkg = {
     name: 'empty',
   };
-
   lib.add(pkg, 'test', v, undefined, 'yarn');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.test).toContain('snyk test');
-  expect(pkg.dependencies.snyk).toBe('^' + v);
 
   expect(pkg).toEqual({
     name: 'empty',
@@ -104,36 +161,66 @@ it('add(test && protect) on empty package', () => {
   });
 });
 
-
 it('already testing moves to prod deps when protect', () => {
-  const pkg = getPkg();
-  const oldVersion = '1.0.0';
-  pkg.devDependencies.snyk = oldVersion;
-  pkg.scripts.test = ' && snyk test';
-
+  const pkg = {
+    scripts: {
+      test: ' && snyk test',
+    },
+    devDependencies: {
+      snyk: '1.0.0',
+    },
+  };
+  
   lib.add(pkg, 'protect', v, 'prepare', 'yarn');
-  expect(pkg.scripts.prepare).toContain('yarn run snyk-protect');
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.devDependencies.snyk).toBeUndefined();
-  expect(pkg.snyk).toBe(true);
+
+  expect(pkg).toEqual({
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      prepare: 'yarn run snyk-protect',
+      test: ' && snyk test',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+    },
+    devDependencies: {},
+    snyk: true,
+  });
 });
 
 it('update the same script that exists (protect with extra commands) from npm to yarn', () => {
   const pkg = loadFile('with-prepublish-npm-but-now-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect && yarn run build');
-  expect(pkg.scripts.prepare).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      prepublish: 'yarn run snyk-protect && yarn run build',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies
+    },
+    snyk: true,
+  });
 });
 
 it('update the same script that exists (protect) from npm to yarn', () => {
   const pkg = loadFile('npm-with-prepublish-simple-now-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect');
-  expect(pkg.scripts.prepare).toBeUndefined();
 
-  expect(pkg.dependencies.snyk).toBe('^' + v);
-  expect(pkg.snyk).toBe(true);
+  expect(pkg).toEqual({
+    name: 'package-lock-exact-match',
+    version: '1.0.0',
+    scripts: {
+      'snyk-protect': 'snyk protect',
+      prepublish: 'yarn run snyk-protect',
+    },
+    dependencies: {
+      snyk: `^${v}`,
+      ...fixtureDependencies
+    },
+    snyk: true,
+  });
 });

--- a/test/npm.test.js
+++ b/test/npm.test.js
@@ -1,4 +1,3 @@
-const { test } = require('tap');
 const lib = require('../lib');
 const fs = require('fs');
 const v = '2.0.0';
@@ -11,111 +10,95 @@ function loadFile(fileName) {
   return JSON.parse(fs.readFileSync(__dirname + '/fixtures/' + fileName, 'utf8'));
 }
 
-test('add(test)', t => {
+it('add(test)', () => {
   const pkg = getPkg();
 
   lib.add(pkg, 'test', v);
-  t.match(pkg.scripts.test, 'snyk test', 'contains test command');
-  t.equal(pkg.devDependencies.snyk, '^' + v, 'includes snyk and latest');
-
-  t.end();
+  expect(pkg.scripts.test).toContain('snyk test');
+  expect(pkg.devDependencies.snyk).toBe('^' + v);
 });
 
-test('add(protect)', t => {
+it('add(protect)', () => {
   const pkg = getPkg();
 
   lib.add(pkg, 'protect', v);
-  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepublish, 'does not contain prepublish');
+  expect(pkg.scripts.prepare).toContain('npm run snyk-protect');
+  expect(pkg.scripts.prepublish).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('script exists but not snyk protect (protect)', t => {
+it('script exists but not snyk protect (protect)', () => {
   const pkg = loadFile('missing-snyk-protect-package.json');
 
   lib.add(pkg, 'protect', v);
-  t.match(pkg.scripts.prepublish, 'npm run snyk-protect', 'prepublish preserved');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.scripts.prepublish).toContain('npm run snyk-protect');
+  expect(pkg.scripts.prepare).toBeUndefined();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('do not add another script if one exists (protect)', t => {
+it('do not add another script if one exists (protect)', () => {
   const pkg = loadFile('with-prepublish-package.json');
   lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepublish, 'npm run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  expect(pkg.scripts.prepublish).toContain('npm run snyk-protect');
+  expect(pkg.scripts.prepare).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('update the same script that exists (protect)', t => {
+it('update the same script that exists (protect)', () => {
   const pkg = loadFile('prepublish-without-snyk-package.json');
   lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepublish, 'npm run snyk-protect && npm run build', 'contains protect command');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  expect(pkg.scripts.prepublish).toBe('npm run snyk-protect && npm run build');
+  expect(pkg.scripts.prepare).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('if both prepare/prepublish exists update first one (protect)', t => {
+it('if both prepare/prepublish exists update first one (protect)', () => {
   const pkg = loadFile('with-prepare-and-prepublish-package.json');
   lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepare, 'npm run snyk-protect && npm run test', 'contains protect command');
-  t.equal(pkg.scripts.prepublish, 'npm run build', 'prepublish not changed');
+  expect(pkg.scripts.prepare).toBe('npm run snyk-protect && npm run test');
+  expect(pkg.scripts.prepublish).toBe('npm run build');
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('default to prepare (protect)', t => {
+it('default to prepare (protect)', () => {
   const pkg = getPkg();
   lib.add(pkg, 'protect', v);
-  t.equal(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepublish, 'prepublish not added');
+  expect(pkg.scripts.prepare).toBe('npm run snyk-protect');
+  expect(pkg.scripts.prepublish).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('add(protect) npm 5', t => {
+it('add(protect) npm 5', () => {
   const pkg = getPkg();
 
   lib.add(pkg, 'protect', v, 'prepare');
-  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.scripts.prepare).toContain('npm run snyk-protect');
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('add(test && protect) on empty package', t => {
+it('add(test && protect) on empty package', () => {
   const pkg = {
     name: 'empty',
   };
 
   lib.add(pkg, 'test', v);
   lib.add(pkg, 'protect', v);
-  t.match(pkg.scripts.test, 'snyk test', 'contains test command');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  expect(pkg.scripts.test).toContain('snyk test');
+  expect(pkg.dependencies.snyk).toBe('^' + v);
 
-  t.deepEqual(pkg, {
+  expect(pkg).toEqual({
     name: 'empty',
     scripts: {
       'snyk-protect': 'snyk protect',
@@ -127,23 +110,18 @@ test('add(test && protect) on empty package', t => {
       snyk: `^${v}`,
     },
     snyk: true,
-  }, 'structured as expected');
-
-  t.end();
+  });
 });
 
-
-test('already testing moves to prod deps when protect', t => {
+it('already testing moves to prod deps when protect', () => {
   const pkg = getPkg();
   const oldVersion = '1.0.0';
   pkg.devDependencies.snyk = oldVersion;
   pkg.scripts.test = ' && snyk test';
 
   lib.add(pkg, 'protect', v, 'prepare');
-  t.match(pkg.scripts.prepare, 'npm run snyk-protect', 'contains protect command');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.isa(pkg.devDependencies.snyk, undefined, 'snyk stripped from devDeps');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.scripts.prepare).toContain('npm run snyk-protect');
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.devDependencies.snyk).toBeUndefined();
+  expect(pkg.snyk).toBe(true);
 });

--- a/test/unit/lib/index.test.js
+++ b/test/unit/lib/index.test.js
@@ -1,0 +1,197 @@
+const lib = require("../../../lib/index");
+
+describe("isProtecting", () => {
+  it("returns false if protect command found in any of `prepare`, `prepare`, or `postinstall`", () => {
+    const pkg = {
+      scripts: {},
+    };
+    const protecting = lib.isProtecting(pkg, "npm");
+    expect(protecting).toBe(false);
+  });
+
+  it("returns true if protect command found in `prepare`", () => {
+    const pkg = {
+      scripts: {
+        prepare: "npm run snyk-protect",
+      },
+    };
+    const protecting = lib.isProtecting(pkg, "npm");
+    expect(protecting).toBe(true);
+  });
+
+  it("returns true if protect command found in `prepublish`", () => {
+    const pkg = {
+      scripts: {
+        prepublish: "npm run snyk-protect",
+      },
+    };
+    const protecting = lib.isProtecting(pkg, "npm");
+    expect(protecting).toBe(true);
+  });
+
+  it("returns true if protect command found in `postinstall`", () => {
+    const pkg = {
+      scripts: {
+        postinstall: "npm run snyk-protect",
+      },
+    };
+    const protecting = lib.isProtecting(pkg, "npm");
+    expect(protecting).toBe(true);
+  });
+});
+
+describe("updateSnykProtectDependency", () => {
+  describe("if not protecting", () => {
+    it("removes `@snyk/protect` from all dependency lists", () => {
+      const pkg = {
+        scripts: {},
+        dependencies: {
+          "@snyk/protect": "1.600.0",
+        },
+        devDependencies: {
+          "@snyk/protect": "1.600.0",
+        },
+        peerDependencies: {
+          "@snyk/protect": "1.600.0",
+        },
+        optionalDependencies: {
+          "@snyk/protect": "1.600.0",
+        },
+      };
+      lib.updateSnykProtectDependency(pkg, false, "1.650.0");
+      expect(pkg.dependencies).toEqual({});
+      expect(pkg.devDependencies).toEqual({});
+      expect(pkg.peerDependencies).toEqual({});
+      expect(pkg.optionalDependencies).toEqual({});
+    });
+  });
+
+  describe("if protecting", () => {
+    it("adds `@snyk/protect` to `dependencies` when not already there", () => {
+      const pkg = {};
+      lib.updateSnykProtectDependency(pkg, true, "1.650.0");
+      expect(pkg).toEqual({
+        dependencies: {
+          "@snyk/protect": "^1.650.0",
+        },
+      });
+    });
+
+    it("updates the `@snyk/protect` version in `dependencies` when already there", () => {
+      const pkg = {
+        dependencies: {
+          "@snyk/protect": "^1.600.0",
+        },
+      };
+      lib.updateSnykProtectDependency(pkg, true, "1.650.0");
+      expect(pkg).toEqual({
+        dependencies: {
+          "@snyk/protect": "^1.650.0",
+        },
+      });
+    });
+  });
+});
+
+describe("updateSnykDependency", () => {
+  describe("when not testing", () => {
+    it("removes `snyk` from all dependency lists", () => {
+      const pkg = {
+        scripts: {}, // no test script with 'snyk test' -> not testing
+        dependencies: {
+          snyk: "1.600.0",
+        },
+        devDependencies: {
+          snyk: "1.600.0",
+        },
+        peerDependencies: {
+          snyk: "1.600.0",
+        },
+        optionalDependencies: {
+          snyk: "1.600.0",
+        },
+      };
+      lib.updateSnykDependency(pkg, false, "1.650.0");
+      expect(pkg.dependencies).toEqual({});
+      expect(pkg.devDependencies).toEqual({});
+      expect(pkg.peerDependencies).toEqual({});
+      expect(pkg.optionalDependencies).toEqual({});
+    });
+  });
+
+  describe("when testing", () => {
+    it("adds `snyk` to devDependencies list", () => {
+      const pkg = {};
+      lib.updateSnykDependency(pkg, true, "1.650.0");
+      expect(pkg).toEqual({
+        devDependencies: {
+          snyk: "^1.650.0",
+        },
+      });
+    });
+  });
+});
+
+describe("isTesting", () => {
+  describe("returns true", () => {
+    it("when `test` script is `snyk test`", () => {
+      const pkg = {
+        scripts: {
+          test: "snyk test",
+        },
+      };
+      expect(lib.isTesting(pkg)).toBe(true);
+    });
+
+    it("when `test` script contains `snyk test` and other stuff", () => {
+      expect(
+        lib.isTesting({
+          scripts: {
+            test: "jest && snyk test",
+          },
+        })
+      ).toBe(true);
+      expect(
+        lib.isTesting({
+          scripts: {
+            test: "snyk test && jest",
+          },
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("returns false", () => {
+    it("when `scripts` is missing", () => {
+      expect(lib.isTesting({})).toBe(false);
+    });
+
+    it("when `test` script is missing", () => {
+      expect(
+        lib.isTesting({
+          scripts: {},
+        })
+      ).toBe(false);
+    });
+
+    it("when `test` script is ``", () => {
+      expect(
+        lib.isTesting({
+          scripts: {
+            test: "",
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("when `test` script is contains stuff not containing `snyk test`", () => {
+      expect(
+        lib.isTesting({
+          scripts: {
+            test: "jest",
+          },
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/test/unit/lib/index.test.js
+++ b/test/unit/lib/index.test.js
@@ -72,7 +72,7 @@ describe("updateSnykProtectDependency", () => {
       lib.updateSnykProtectDependency(pkg, true, "1.650.0");
       expect(pkg).toEqual({
         dependencies: {
-          "@snyk/protect": "^1.650.0",
+          "@snyk/protect": "latest",
         },
       });
     });
@@ -86,7 +86,7 @@ describe("updateSnykProtectDependency", () => {
       lib.updateSnykProtectDependency(pkg, true, "1.650.0");
       expect(pkg).toEqual({
         dependencies: {
-          "@snyk/protect": "^1.650.0",
+          "@snyk/protect": "latest",
         },
       });
     });

--- a/test/yarn.test.js
+++ b/test/yarn.test.js
@@ -1,4 +1,3 @@
-const { test } = require('tap');
 const lib = require('../lib');
 const fs = require('fs');
 const v = '2.0.0';
@@ -11,99 +10,85 @@ function loadFile(fileName) {
   return JSON.parse(fs.readFileSync(__dirname + '/fixtures/' + fileName, 'utf8'));
 }
 
-test('add(test)', t => {
+it('add(test)', () => {
   const pkg = getPkg();
 
   lib.add(pkg, 'test', v, undefined, 'yarn');
-  t.match(pkg.scripts.test, 'snyk test', 'contains test command');
-  t.equal(pkg.devDependencies.snyk, '^' + v, 'includes snyk and latest');
-
-  t.end();
+  expect(pkg.scripts.test).toContain('snyk test');
+  expect(pkg.devDependencies.snyk).toBe('^' + v);
 });
 
-test('add(protect)', t => {
+it('add(protect)', () => {
   const pkg = getPkg();
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.match(pkg.scripts.prepare, 'yarn run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepublish, 'does not contain prepublish');
+  expect(pkg.scripts.prepare).toContain('yarn run snyk-protect');
+  expect(pkg.scripts.prepublish).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('script exists but not snyk protect (protect)', t => {
+it('script exists but not snyk protect (protect)', () => {
   const pkg = loadFile('missing-snyk-protect-package-yarn.json');
 
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.match(pkg.scripts.prepublish, 'yarn run snyk-protect', 'prepublish preserved');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.scripts.prepublish).toContain('yarn run snyk-protect');
+  expect(pkg.scripts.prepare).toBeUndefined();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('do not add another script if one exists (protect)', t => {
+it('do not add another script if one exists (protect)', () => {
   const pkg = loadFile('with-prepublish-package-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect');
+  expect(pkg.scripts.prepare).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('update the same script that exists (protect)', t => {
+it('update the same script that exists (protect)', () => {
   const pkg = loadFile('prepublish-without-snyk-package-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect && yarn run build', 'contains protect command');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect && yarn run build');
+  expect(pkg.scripts.prepare).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('if both prepare/prepublish exists update first one (protect)', t => {
+it('if both prepare/prepublish exists update first one (protect)', () => {
   const pkg = loadFile('with-prepare-and-prepublish-package-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.equal(pkg.scripts.prepare, 'yarn run snyk-protect && yarn run test', 'contains protect command');
-  t.equal(pkg.scripts.prepublish, 'yarn run build', 'prepublish not changed');
+  expect(pkg.scripts.prepare).toBe('yarn run snyk-protect && yarn run test');
+  expect(pkg.scripts.prepublish).toBe('yarn run build');
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('default to prepare (protect)', t => {
+it('default to prepare (protect)', () => {
   const pkg = getPkg();
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.equal(pkg.scripts.prepare, 'yarn run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepublish, 'prepublish not added');
+  expect(pkg.scripts.prepare).toBe('yarn run snyk-protect');
+  expect(pkg.scripts.prepublish).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('add(test && protect) on empty package', t => {
+it('add(test && protect) on empty package', () => {
   const pkg = {
     name: 'empty',
   };
 
   lib.add(pkg, 'test', v, undefined, 'yarn');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.match(pkg.scripts.test, 'snyk test', 'contains test command');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
+  expect(pkg.scripts.test).toContain('snyk test');
+  expect(pkg.dependencies.snyk).toBe('^' + v);
 
-  t.deepEqual(pkg, {
+  expect(pkg).toEqual({
     name: 'empty',
     scripts: {
       'snyk-protect': 'snyk protect',
@@ -115,47 +100,39 @@ test('add(test && protect) on empty package', t => {
       snyk: `^${v}`,
     },
     snyk: true,
-  }, 'structured as expected');
-
-  t.end();
+  });
 });
 
 
-test('already testing moves to prod deps when protect', t => {
+it('already testing moves to prod deps when protect', () => {
   const pkg = getPkg();
   const oldVersion = '1.0.0';
   pkg.devDependencies.snyk = oldVersion;
   pkg.scripts.test = ' && snyk test';
 
   lib.add(pkg, 'protect', v, 'prepare', 'yarn');
-  t.match(pkg.scripts.prepare, 'yarn run snyk-protect', 'contains protect command');
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.isa(pkg.devDependencies.snyk, undefined, 'snyk stripped from devDeps');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.scripts.prepare).toContain('yarn run snyk-protect');
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.devDependencies.snyk).toBeUndefined();
+  expect(pkg.snyk).toBe(true);
 });
 
-test('update the same script that exists (protect with extra commands) from npm to yarn', t => {
+it('update the same script that exists (protect with extra commands) from npm to yarn', () => {
   const pkg = loadFile('with-prepublish-npm-but-now-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect && yarn run build', 'contains protect command');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect && yarn run build');
+  expect(pkg.scripts.prepare).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });
 
-test('update the same script that exists (protect) from npm to yarn', t => {
+it('update the same script that exists (protect) from npm to yarn', () => {
   const pkg = loadFile('npm-with-prepublish-simple-now-yarn.json');
   lib.add(pkg, 'protect', v, undefined, 'yarn');
-  t.equal(pkg.scripts.prepublish, 'yarn run snyk-protect', 'contains protect command');
-  t.ok(!pkg.scripts.prepare, 'prepare not added');
+  expect(pkg.scripts.prepublish).toBe('yarn run snyk-protect');
+  expect(pkg.scripts.prepare).toBeUndefined();
 
-  t.equal(pkg.dependencies.snyk, '^' + v, 'includes snyk and latest');
-  t.equal(pkg.snyk, true, 'flagged as snyk');
-
-  t.end();
+  expect(pkg.dependencies.snyk).toBe('^' + v);
+  expect(pkg.snyk).toBe(true);
 });


### PR DESCRIPTION
Use the new `@snyk/protect` package to apply Snyk patches rather than the entire `snyk` package.
