### PR TITLE
Use fixed major version of semantic release from dev deps

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-node-14-${{ hashFiles('**/package.json') }}
           restore-keys: ${{ runner.os }}-node-14-
       - run: npm install
-      - run: npx semantic-release
+      - run: npm run release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   "scripts": {
     "cover": "tap -R spec --cov --coverage-report=lcov test/*.test.js",
     "test": "tap -R spec test/*.test.js",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "release": "semantic-release"
   },
   "keywords": [],
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
+    "semantic-release": "^17.4.4",
     "tap": "^12.6.1"
   },
-  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/add-to-package.git"


### PR DESCRIPTION
Add `semantic-release` to devDependencies so that we can control the (major) version. This way a new major version with a breaking change will not cause us problems.