### PR TITLE
[PRODSEC-3273]: Change secrets scanning channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
-          channel: os-team-managed-alerts
+          channel: snyk-vuln-alerts-sca
           filters:
             branches:
               ignore:


### PR DESCRIPTION
[PRODSEC-3273]: Change secrets scanning channel from os-team-managed-alerts to snyk-vuln-alerts-sca

-- 
Committed by prodsec-tools-v2 using octopilot

[PRODSEC-3273]: https://snyksec.atlassian.net/browse/PRODSEC-3273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ